### PR TITLE
[Minor Fix] Using `path()` instead of `file()` on all modules

### DIFF
--- a/modules/ariba/ariba_analysis/ariba_analysis.nf
+++ b/modules/ariba/ariba_analysis/ariba_analysis.nf
@@ -8,8 +8,8 @@ process ARIBA_ANALYSIS {
     publishDir "${outdir}/${sample}/ariba", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "${dataset_name}/*"
 
     input:
-    tuple val(sample), val(single_end), file(fq)
-    each file(dataset)
+    tuple val(sample), val(single_end), path(fq)
+    each path(dataset)
 
     output:
     file "${dataset_name}/*"
@@ -19,14 +19,14 @@ process ARIBA_ANALYSIS {
     single_end == false && ARIBA_DATABASES.isEmpty() == false
 
     shell:
-    dataset_tarball = file(dataset).getName()
+    dataset_tarball = path(dataset).getName()
     dataset_name = dataset_tarball.replace('.tar.gz', '')
     spades_options = params.spades_options ? "--spades_options '${params.spades_options}'" : ""
     noclean = params.ariba_no_clean ? "--noclean" : ""
 
     template "ariba_analysis.sh"
     stub:
-    dataset_tarball = file(dataset).getName()
+    dataset_tarball = path(dataset).getName()
     dataset_name = dataset_tarball.replace('.tar.gz', '')
     """
     mkdir ${dataset_name}
@@ -44,8 +44,8 @@ workflow test {
     TEST_PARAMS_CH = Channel.of([
         params.sample,
         params.single_end,
-        file(params.fq)
+        path(params.fq)
         ])
-    TEST_PARAMS_CH2 = Channel.of(file(params.card),file(params.vfdb))
+    TEST_PARAMS_CH2 = Channel.of(path(params.card),path(params.vfdb))
     ariba_analysis(TEST_PARAMS_CH,TEST_PARAMS_CH2.collect())
 }

--- a/modules/blast/blast_genes/blast_genes.nf
+++ b/modules/blast/blast_genes/blast_genes.nf
@@ -10,11 +10,11 @@ process BLAST_GENES {
     publishDir "${outdir}/${sample}/blast", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "genes/*.{json,json.gz}"
 
     input:
-    tuple val(sample), file(blastdb)
-    file(query)
+    tuple val(sample), path(blastdb)
+    path(query)
 
     output:
-    file("genes/*.{json,json.gz}")
+    path("genes/*.{json,json.gz}")
     file "${task.process}/*" optional true
 
     when:
@@ -40,10 +40,10 @@ process BLAST_GENES {
 workflow test {
     TEST_PARAMS_CH = Channel.of([
         params.sample,
-        file(params.blastdb),
+        path(params.blastdb),
         ])
     TEST_PARAMS_CH2 = Channel.of(
-        file(params.query)
+        path(params.query)
         )
 
     blast_genes(TEST_PARAMS_CH,TEST_PARAMS_CH2)

--- a/modules/blast/blast_primers/blast_primers.nf
+++ b/modules/blast/blast_primers/blast_primers.nf
@@ -10,11 +10,11 @@ process BLAST_PRIMERS {
     publishDir "${outdir}/${sample}/blast", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "primers/*.{json,json.gz}"
 
     input:
-    tuple val(sample), file(blastdb)
-    file(query)
+    tuple val(sample), path(blastdb)
+    path(query)
 
     output:
-    file("primers/*.{json,json.gz}")
+    path("primers/*.{json,json.gz}")
     file "${task.process}/*" optional true
 
     when:
@@ -40,10 +40,10 @@ process BLAST_PRIMERS {
 workflow test {
     TEST_PARAMS_CH = Channel.of([
         params.sample,
-        file(params.blastdb),
+        path(params.blastdb),
         ])
     TEST_PARAMS_CH2 = Channel.of(
-        file(params.query)
+        path(params.query)
         )
 
     blast_primers(TEST_PARAMS_CH,TEST_PARAMS_CH2)

--- a/modules/blast/blast_proteins/blast_proteins.nf
+++ b/modules/blast/blast_proteins/blast_proteins.nf
@@ -10,11 +10,11 @@ process BLAST_PROTEINS {
     publishDir "${outdir}/${sample}/blast", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "proteins/*.{json,json.gz}"
 
     input:
-    tuple val(sample), file(blastdb)
-    file(query)
+    tuple val(sample), path(blastdb)
+    path(query)
 
     output:
-    file("proteins/*.{json,json.gz}")
+    path("proteins/*.{json,json.gz}")
     file "${task.process}/*" optional true
 
     when:
@@ -41,10 +41,10 @@ process BLAST_PROTEINS {
 workflow test {
     TEST_PARAMS_CH = Channel.of([
         params.sample,
-        file(params.blastdb),
+        path(params.blastdb),
         ])
     TEST_PARAMS_CH2 = Channel.of(
-        file(params.query)
+        path(params.query)
         )
 
     blast_proteins(TEST_PARAMS_CH,TEST_PARAMS_CH2)

--- a/modules/blast/make_blastdb/make_blastdb.nf
+++ b/modules/blast/make_blastdb/make_blastdb.nf
@@ -8,11 +8,11 @@ process MAKE_BLASTDB {
     publishDir "${outdir}/${sample}/blast", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "blastdb/*"
 
     input:
-    tuple val(sample), val(single_end), file(fasta)
+    tuple val(sample), val(single_end), path(fasta)
 
     output:
-    file("blastdb/*")
-    tuple val(sample), file("blastdb/*"), emit: BLAST_DB, optional:true
+    path("blastdb/*")
+    tuple val(sample), path("blastdb/*"), emit: BLAST_DB, optional:true
     file "${task.process}/*" optional true
 
     shell:
@@ -36,7 +36,7 @@ workflow test{
     TEST_PARAMS_CH = Channel.of([
         params.sample,
         params.single_end,
-        file(params.fasta)
+        path(params.fasta)
     ])
 
     make_blastdb(TEST_PARAMS_CH)

--- a/modules/blast/plasmid_blast/plasmid_blast.nf
+++ b/modules/blast/plasmid_blast/plasmid_blast.nf
@@ -10,12 +10,12 @@ process PLASMID_BLAST {
     publishDir "${outdir}/${sample}/blast", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "*.{json,json.gz}"
 
     input:
-    tuple val(sample), file(genes)
-    file(blastdb_files)
+    tuple val(sample), path(genes)
+    path(blastdb_files)
 
     output:
-    file("${sample}-plsdb.{json,json.gz}")
-    file "${task.process}/*" optional true
+    path("${sample}-plsdb.{json,json.gz}")
+    path("${task.process}/*" optional true
 
     when:
     PLASMID_BLASTDB.isEmpty() == false
@@ -41,10 +41,10 @@ process PLASMID_BLAST {
 workflow test {
     TEST_PARAMS_CH = Channel.of([
         params.sample, 
-        params.genes,          
+        path(params.genes),          
         ])
     TEST_PARAMS_CH2 = Channel.of(
-        params.blastdb_files
+        path(params.blastdb_files)
         )
 
     plasmid_blast(TEST_PARAMS_CH,TEST_PARAMS_CH2)

--- a/modules/bwa/mapping_query/mapping_query.nf
+++ b/modules/bwa/mapping_query/mapping_query.nf
@@ -10,8 +10,8 @@ process MAPPING_QUERY {
     publishDir "${outdir}/${sample}", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "mapping/*"
 
     input:
-    tuple val(sample), val(single_end), file(fq)
-    each file(query)
+    tuple val(sample), val(single_end), path(fq)
+    each path(query)
 
     output:
     file "mapping/*"
@@ -44,10 +44,10 @@ workflow test{
     TEST_PARAMS_CH = Channel.of([
         params.sample,
         params.single_end,
-        file(params.fq)
+        path(params.fq)
         ])
     TEST_PARAMS_CH2 = Channel.of(
-        file(params.query)
+        path(params.query)
         )
     mapping_query(TEST_PARAMS_CH,TEST_PARAMS_CH2.collect())
 }

--- a/modules/mash/antimicrobial_resistance/antimicrobial_resistance.nf
+++ b/modules/mash/antimicrobial_resistance/antimicrobial_resistance.nf
@@ -11,12 +11,12 @@ process ANTIMICROBIAL_RESISTANCE {
     publishDir "${outdir}/${sample}", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "${amrdir}/*"
 
     input:
-    tuple val(sample), file(genes), file(proteins)
-    each file(amrdb)
+    tuple val(sample), path(genes), path(proteins)
+    each path(amrdb)
 
     output:
-    file "${amrdir}/*"
-    file "logs/*" optional true
+    path "${amrdir}/*"
+    path "logs/*" optional true
 
     shell:
     amrdir = "antimicrobial-resistance"
@@ -47,11 +47,11 @@ process ANTIMICROBIAL_RESISTANCE {
 workflow test {
     TEST_PARAMS_CH = Channel.of([
         params.sample,
-        file(params.genes),
-        file(params.proteins)
+        path(params.genes),
+        path(params.proteins)
         ])
     TEST_PARAMS_CH2 = Channel.of(
-        file(params.amrdb)
+        path(params.amrdb)
         )
     antimicrobial_resistance(TEST_PARAMS_CH,TEST_PARAMS_CH2.collect())
 }

--- a/modules/mash/estimate_genome_size/estimate_genome_size.nf
+++ b/modules/mash/estimate_genome_size/estimate_genome_size.nf
@@ -8,14 +8,14 @@ process ESTIMATE_GENOME_SIZE {
     publishDir "${params.outdir}/${sample}", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: '*.txt'
 
     input:
-    tuple val(sample), val(sample_type), val(single_end), file(fq), file(extra)
+    tuple val(sample), val(sample_type), val(single_end), path(fq), path(extra)
 
     output:
-    file "${sample}-genome-size-error.txt" optional true
-    file("${sample}-genome-size.txt") optional true
+    path "${sample}-genome-size-error.txt" optional true
+    path("${sample}-genome-size.txt") optional true
     tuple val(sample), val(sample_type), val(single_end), 
-        file("fastqs/${sample}*.fastq.gz"), file(extra), file("${sample}-genome-size.txt"),emit: QUALITY_CONTROL, optional: true
-    file "${task.process}/*" optional true
+        path("fastqs/${sample}*.fastq.gz"), path(extra), path("${sample}-genome-size.txt"),emit: QUALITY_CONTROL, optional: true
+    path "${task.process}/*" optional true
 
     shell:
     genome_size = SPECIES_GENOME_SIZE
@@ -42,8 +42,8 @@ workflow test {
         params.sample, 
         params.sample_type, 
         params.single_end,
-        file(params.fq),
-        file(params.extra)             
+        path(params.fq),
+        path(params.extra)             
         ])
 
     estimate_genome_size(TEST_PARAMS_CH)

--- a/modules/mccortex/count_31mers/count_31mers.nf
+++ b/modules/mccortex/count_31mers/count_31mers.nf
@@ -8,10 +8,10 @@ process COUNT_31MERS {
     publishDir "${outdir}/${sample}/kmers", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "*.ctx"
 
     input:
-    tuple val(sample), val(single_end), file(fq)
+    tuple val(sample), val(single_end), path(fq)
     output:
-    file "${sample}.ctx"
-    file "${task.process}/*" optional true
+    path "${sample}.ctx"
+    path "${task.process}/*" optional true
 
     shell:
     m = task.memory.toString().split(' ')[0].toInteger() * 1000 - 500
@@ -34,7 +34,7 @@ workflow test{
     TEST_PARAMS_CH = Channel.of([
         params.sample,
         params.single_end,
-        file(params.fq)
+        path(params.fq)
         ])
 
     count_31mers(TEST_PARAMS_CH)

--- a/modules/minmer/minmer_query/minmer_query.nf
+++ b/modules/minmer/minmer_query/minmer_query.nf
@@ -11,12 +11,12 @@ process MINMER_QUERY {
     publishDir "${outdir}/${sample}/minmers", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "*.txt"
 
     input:
-    tuple val(sample), val(single_end), file(fq), file(sourmash)
-    each file(dataset)
+    tuple val(sample), val(single_end), path(fq), path(sourmash)
+    each path(dataset)
 
     output:
-    file "*.txt"
-    file "${task.process}/*" optional true
+    path "*.txt"
+    path "${task.process}/*" optional true
 
     when:
     MINMER_DATABASES.isEmpty() == false
@@ -44,9 +44,9 @@ workflow test {
     TEST_PARAMS_CH = Channel.of([
         params.sample,
         params.single_end,
-        file(params.fq),
-        file(params.sourmash)
+        path(params.fq),
+        path(params.sourmash)
     ])
-    TEST_PARAMS_CH2 = Channel.of(file(params.k21),file(params.k31),file(params.k51),file(params.refseqk21))
+    TEST_PARAMS_CH2 = Channel.of(path(params.k21),path(params.k31),path(params.k51),path(params.refseqk21))
     minmer_query(TEST_PARAMS_CH,TEST_PARAMS_CH2.collect())
 }

--- a/modules/minmer/minmer_sketch/minmer_sketch.nf
+++ b/modules/minmer/minmer_sketch/minmer_sketch.nf
@@ -11,13 +11,13 @@ process MINMER_SKETCH {
     publishDir "${outdir}/${sample}/minmers", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "*.{msh,sig}"
 
     input:
-    tuple val(sample), val(single_end), file(fq)
+    tuple val(sample), val(single_end), path(fq)
 
     output:
-    file("${sample}*.{msh,sig}")
-    tuple val(sample), val(single_end), file("fastqs/${sample}*.fastq.gz"), file("${sample}.sig"),emit: MINMER_QUERY
-    tuple val(sample), val(single_end), file("fastqs/${sample}*.fastq.gz"), file("${sample}-k31.msh"),emit: DOWNLOAD_REFERENCES
-    file "${task.process}/*" optional true
+    path("${sample}*.{msh,sig}")
+    tuple val(sample), val(single_end), path("fastqs/${sample}*.fastq.gz"), path("${sample}.sig"),emit: MINMER_QUERY
+    tuple val(sample), val(single_end), path("fastqs/${sample}*.fastq.gz"), path("${sample}-k31.msh"),emit: DOWNLOAD_REFERENCES
+    path "${task.process}/*" optional true
 
     shell:
     fastq = single_end ? fq[0] : "${fq[0]} ${fq[1]}"
@@ -43,7 +43,7 @@ workflow test {
     TEST_PARAMS_CH = Channel.of([
         params.sample,
         params.single_end,
-        file(params.fq)
+        path(params.fq)
         ])
 
     minmer_sketch(TEST_PARAMS_CH)

--- a/modules/shovill/assemble_genome/assemble_genome.nf
+++ b/modules/shovill/assemble_genome/assemble_genome.nf
@@ -9,16 +9,16 @@ process ASSEMBLE_GENOME {
     publishDir "${outdir}/${sample}", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "${sample}-assembly-error.txt"
 
     input:
-    tuple val(sample), val(sample_type), val(single_end), file(fq), file(extra), file(genome_size)
+    tuple val(sample), val(sample_type), val(single_end), path(fq), path(extra), path(genome_size)
 
     output:
-    file "assembly/*"
-    file "${sample}-assembly-error.txt" optional true
-    tuple val(sample), val(single_end), file("fastqs/${sample}*.fastq.gz"), file("assembly/${sample}.{fna,fna.gz}"),emit: SEQUENCE_TYPE, optional:true
-    tuple val(sample), val(single_end), file("assembly/${sample}.{fna,fna.gz}"), emit: MAKE_BLASTDB, optional: true
-    tuple val(sample), val(single_end), file("fastqs/${sample}*.fastq.gz"), file("assembly/${sample}.{fna,fna.gz}"), file("total_contigs_*"),emit: ANNOTATION, optional:true
-    tuple val(sample), file("assembly/${sample}.{fna,fna.gz}"), file(genome_size),emit: ASSEMBLY_QC, optional: true
-    file "${task.process}/*" optional true
+    path "assembly/*"
+    path "${sample}-assembly-error.txt" optional true
+    tuple val(sample), val(single_end), path("fastqs/${sample}*.fastq.gz"), path("assembly/${sample}.{fna,fna.gz}"),emit: SEQUENCE_TYPE, optional:true
+    tuple val(sample), val(single_end), path("assembly/${sample}.{fna,fna.gz}"), emit: MAKE_BLASTDB, optional: true
+    tuple val(sample), val(single_end), path("fastqs/${sample}*.fastq.gz"), path("assembly/${sample}.{fna,fna.gz}"), path("total_contigs_*"),emit: ANNOTATION, optional:true
+    tuple val(sample), path("assembly/${sample}.{fna,fna.gz}"), path(genome_size),emit: ASSEMBLY_QC, optional: true
+    path "${task.process}/*" optional true
 
     shell:
     shovill_ram = task.memory.toString().split(' ')[0]
@@ -61,9 +61,9 @@ workflow test{
         params.sample,
         params.sample_type,
         params.single_end,
-        file(params.fq),
-        file(params.extra),
-        file(params.genome_size)
+        path(params.fq),
+        path(params.extra),
+        path(params.genome_size)
         ])
 
     assemble_genome(TEST_PARAMS_CH)

--- a/modules/utilities/download_references/download_references.nf
+++ b/modules/utilities/download_references/download_references.nf
@@ -14,12 +14,12 @@ process DOWNLOAD_REFERENCES {
     publishDir "${outdir}/${sample}/variants/auto", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: 'mash-dist.txt'
 
     input:
-    tuple val(sample), val(single_end), file(fq), file(sample_sketch)
-    file(refseq_sketch)
+    tuple val(sample), val(single_end), path(fq), path(sample_sketch)
+    path(refseq_sketch)
 
     output:
-    tuple val(sample), val(single_end), file("fastqs/${sample}*.fastq.gz"), file("genbank/*.gbk"), emit:CALL_VARIANTS_AUTO, optional: true
-    file("mash-dist.txt")
+    tuple val(sample), val(single_end), path("fastqs/${sample}*.fastq.gz"), path("genbank/*.gbk"), emit:CALL_VARIANTS_AUTO, optional: true
+    path("mash-dist.txt")
     file "${task.process}/*" optional true
 
     when:
@@ -51,11 +51,11 @@ workflow test {
     TEST_PARAMS_CH = Channel.of([
         params.sample,
         params.single_end,
-        file(params.fq),
-        file(params.sample_sketch)
+        path(params.fq),
+        path(params.sample_sketch)
         ])
     TEST_PARAMS_CH2 = Channel.of(
-        file(params.refseq_sketch)
+        path(params.refseq_sketch)
         )
     download_references(TEST_PARAMS_CH,TEST_PARAMS_CH2)
 }

--- a/modules/utilities/fastq_status/fastq_status.nf
+++ b/modules/utilities/fastq_status/fastq_status.nf
@@ -6,11 +6,11 @@ process FASTQ_STATUS {
     publishDir "${params.outdir}/${sample}", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: '*.txt'
 
     input:
-    tuple val(sample), val(sample_type), val(single_end), file(fq), file(extra)
+    tuple val(sample), val(sample_type), val(single_end), path(fq), path(extra)
     output:
     file "*-error.txt" optional true
     tuple val(sample), val(sample_type), val(single_end), 
-        file("fastqs/${sample}*.fastq.gz"), file(extra),emit: ESTIMATE_GENOME_SIZE, optional: true
+        path("fastqs/${sample}*.fastq.gz"), path(extra),emit: ESTIMATE_GENOME_SIZE, optional: true
     file "${task.process}/*" optional true
 
     shell:
@@ -39,8 +39,8 @@ workflow test{
         params.sample, 
         params.sample_type, 
         params.single_end,
-        file(params.fq),
-        file(params.extra)             
+        path(params.fq),
+        path(params.extra)             
         ])
 
     fastq_status(TEST_PARAMS_CH)

--- a/modules/utilities/gather_fastqs/gather_fastqs.nf
+++ b/modules/utilities/gather_fastqs/gather_fastqs.nf
@@ -9,15 +9,15 @@ process GATHER_FASTQS {
     tag "${sample}"
 
     input:
-    tuple val(sample), val(sample_type), val(single_end), file(r1: '*???-r1'), file(r2: '*???-r2'), file(extra)
+    tuple val(sample), val(sample_type), val(single_end), path(r1: '*???-r1'), path(r2: '*???-r2'), path(extra)
 
     output:
-    file("*-error.txt") optional true
+    path("*-error.txt") optional true
     tuple val(sample), val(final_sample_type), val(single_end),
-        file("fastqs/${sample}*.fastq.gz"), file("extra/*.gz"), emit: FASTQ_PE_STATUS, optional: true
-    file("${task.process}/*") optional true
-    file("bactopia.versions") optional true
-    file("multiple-read-sets-merged.txt") optional true
+        path("fastqs/${sample}*.fastq.gz"), path("extra/*.gz"), emit: FASTQ_PE_STATUS, optional: true
+    path("${task.process}/*") optional true
+    path("bactopia.versions") optional true
+    path("multiple-read-sets-merged.txt") optional true
 
     shell:
     bactopia_version = VERSION

--- a/modules/utilities/quality_control/assembly_qc/assembly_qc.nf
+++ b/modules/utilities/quality_control/assembly_qc/assembly_qc.nf
@@ -8,7 +8,7 @@ process ASSEMBLY_QC {
     publishDir "${outdir}/${sample}/assembly", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "${method}/*"
 
     input:
-    tuple val(sample), file(fasta), file(genome_size)
+    tuple val(sample), path(fasta), path(genome_size)
     each method
 
     output:
@@ -39,8 +39,8 @@ workflow test{
 
     TEST_PARAMS_CH = Channel.of([
         params.sample,
-        file(params.fasta),
-        file(params.genome_size)
+        path(params.fasta),
+        path(params.genome_size)
         ])
     TEST_PARAMS_CH2 = Channel.of('checkm', 'quast')
 

--- a/modules/utilities/quality_control/qc_final_summary/qc_final_summary.nf
+++ b/modules/utilities/quality_control/qc_final_summary/qc_final_summary.nf
@@ -8,7 +8,7 @@ process QC_FINAL_SUMMARY {
     publishDir "${outdir}/${sample}", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "quality-control/*"
 
     input:
-    tuple val(sample), val(single_end), file(fq), file(genome_size)
+    tuple val(sample), val(single_end), path(fq), path(genome_size)
 
     output:
     file "quality-control/*"
@@ -36,8 +36,8 @@ workflow test{
     TEST_PARAMS_CH = Channel.of([
         params.sample,
         params.single_end,
-        file(params.fq),
-        file(params.genome_size)
+        path(params.fq),
+        path(params.genome_size)
         ])
 
     qc_final_summary(TEST_PARAMS_CH)

--- a/modules/utilities/quality_control/qc_original_summary/qc_original_summary.nf
+++ b/modules/utilities/quality_control/qc_original_summary/qc_original_summary.nf
@@ -8,7 +8,7 @@ process QC_ORIGINAL_SUMMARY {
     publishDir "${outdir}/${sample}", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "quality-control/*"
 
     input:
-    tuple val(sample), val(sample_type), val(single_end), file(fq), file(extra), file(genome_size)
+    tuple val(sample), val(sample_type), val(single_end), path(fq), path(extra), path(genome_size)
 
     output:
     file "quality-control/*"
@@ -38,9 +38,9 @@ workflow test{
         params.sample,
         params.sample_type,
         params.single_end,
-        file(params.fq),
-        file(params.extra),
-        file(params.genome_size)
+        path(params.fq),
+        path(params.extra),
+        path(params.genome_size)
         ])
 
     qc_original_summary(TEST_PARAMS_CH)

--- a/modules/utilities/quality_control/qc_reads/qc_reads.nf
+++ b/modules/utilities/quality_control/qc_reads/qc_reads.nf
@@ -10,28 +10,28 @@ process QC_READS {
     publishDir "${outdir}/${sample}", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "*error.txt"
 
     input:
-    tuple val(sample), val(sample_type), val(single_end), file(fq), file(extra), file(genome_size)
+    tuple val(sample), val(sample_type), val(single_end), path(fq), path(extra), path(genome_size)
 
     output:
     file "*-error.txt" optional true
     file "quality-control/*"
     tuple val(sample), val(single_end),
-        file("quality-control/${sample}*.fastq.gz"),emit: READS,optional: true//,emit: COUNT_31MERS, ARIBA_ANALYSIS,MINMER_SKETCH, CALL_VARIANTS,MAPPING_QUERY optional true
+        path("quality-control/${sample}*.fastq.gz"),emit: READS,optional: true//,emit: COUNT_31MERS, ARIBA_ANALYSIS,MINMER_SKETCH, CALL_VARIANTS,MAPPING_QUERY optional true
     tuple val(sample), val(sample_type), val(single_end),
-        file("quality-control/${sample}*.fastq.gz"), file(extra),
-        file(genome_size),emit: ASSEMBLY, optional: true
+        path("quality-control/${sample}*.fastq.gz"), path(extra),
+        path(genome_size),emit: ASSEMBLY, optional: true
 
     tuple val(sample), val(single_end),
-        file("quality-control/${sample}*.{fastq,error-fq}.gz"),
-        file(genome_size),emit: QC_FINAL_SUMMARY, optional: true
+        path("quality-control/${sample}*.{fastq,error-fq}.gz"),
+        path(genome_size),emit: QC_FINAL_SUMMARY, optional: true
     file "${task.process}/*" optional true
 
     shell:
     qc_ram = task.memory.toString().split(' ')[0]
     is_assembly = sample_type.startsWith('assembly') ? true : false
     qin = sample_type.startsWith('assembly') ? 'qin=33' : 'qin=auto'
-    adapters = params.adapters ? file(params.adapters) : 'adapters'
-    phix = params.phix ? file(params.phix) : 'phix'
+    adapters = params.adapters ? path(params.adapters) : 'adapters'
+    phix = params.phix ? path(params.phix) : 'phix'
 
     template "qc_reads.sh"
 
@@ -57,9 +57,9 @@ workflow test{
         params.sample,
         params.sample_type,
         params.single_end,
-        file(params.fq),
-        file(params.extra),
-        file(params.genome_size)
+        path(params.fq),
+        path(params.extra),
+        path(params.genome_size)
     ])
     qc_reads(TEST_PARAMS_CH)
 }

--- a/modules/utilities/sequence_type/sequence_type.nf
+++ b/modules/utilities/sequence_type/sequence_type.nf
@@ -8,8 +8,8 @@ process SEQUENCE_TYPE {
     publishDir "${outdir}/${sample}/mlst/${schema}", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "${method}/*"
 
     input:
-    tuple val(sample), val(single_end), file(fq), file(assembly)
-    each file(dataset)
+    tuple val(sample), val(single_end), path(fq), path(assembly)
+    each path(dataset)
 
     output:
     file "${method}/*"
@@ -20,7 +20,7 @@ process SEQUENCE_TYPE {
 
     shell:
     method = dataset =~ /.*blastdb.*/ ? 'blast' : 'ariba'
-    dataset_tarball = file(dataset).getName()
+    dataset_tarball = path(dataset).getName()
     dataset_name = dataset_tarball.replace('.tar.gz', '').split('-')[1]
     schema = dataset_tarball.split('-')[0]
     noclean = params.ariba_no_clean ? "--noclean" : ""
@@ -30,7 +30,7 @@ process SEQUENCE_TYPE {
 
     stub:
     method = dataset =~ /.*blastdb.*/ ? 'blast' : 'ariba'
-    dataset_tarball = file(dataset).getName()
+    dataset_tarball = path(dataset).getName()
     schema = dataset_tarball.split('-')[0]
     """
     mkdir ${method}
@@ -49,12 +49,12 @@ workflow test{
     TEST_PARAMS_CH = Channel.of([
         params.sample,
         params.single_end,
-        file(params.fq),
-        file(params.assembly)
+        path(params.fq),
+        path(params.assembly)
         ])
     TEST_PARAMS_CH2 = Channel.of(
-        file(params.dataset_blast)
-        file(params.dataset_ariba))
+        path(params.dataset_blast)
+        path(params.dataset_ariba))
 
     sequence_type(TEST_PARAMS_CH,TEST_PARAMS_CH2.collect())
 }

--- a/modules/variant_calling/call_variants/call_variants.nf
+++ b/modules/variant_calling/call_variants/call_variants.nf
@@ -11,12 +11,12 @@ process CALL_VARIANTS {
     publishDir "${outdir}/${sample}/variants/user", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "${reference_name}/*"
 
     input:
-    tuple val(sample), val(single_end), file(fq)
-    each file(reference)
+    tuple val(sample), val(single_end), path(fq)
+    each path(reference)
 
     output:
-    file "${reference_name}/*"
-    file "${task.process}/*" optional true
+    path "${reference_name}/*"
+    path "${task.process}/*" optional true
 
     when:
     REFERENCES.isEmpty() == false
@@ -47,10 +47,10 @@ workflow test {
     TEST_PARAMS_CH = Channel.of([
         params.sample,
         params.single_end,
-        file(params.fq),
+        path(params.fq),
         ])
     TEST_PARAMS_CH2 = Channel.of(
-        file(params.reference)
+        path(params.reference)
         )
     call_variants(TEST_PARAMS_CH,TEST_PARAMS_CH2.collect)
 }

--- a/modules/variant_calling/call_variants_auto/call_variants_auto.nf
+++ b/modules/variant_calling/call_variants_auto/call_variants_auto.nf
@@ -11,11 +11,11 @@ process CALL_VARIANTS_AUTO {
     publishDir "${outdir}/${sample}/variants/auto", mode: "${params.publish_mode}", overwrite: params.overwrite, pattern: "${reference_name}/*"
 
     input:
-    tuple val(sample), val(single_end), file(fq), file(reference)
+    tuple val(sample), val(single_end), path(fq), path(reference)
 
     output:
-    file "${reference_name}/*"
-    file "${task.process}/*" optional true
+    path "${reference_name}/*"
+    path "${task.process}/*" optional true
 
     shell:
     snippy_ram = task.memory.toString().split(' ')[0]
@@ -45,8 +45,8 @@ workflow test {
     TEST_PARAMS_CH = Channel.of([
         params.sample,
         params.single_end,
-        file(params.fq),
-        file(params.reference)
+        path(params.fq),
+        path(params.reference)
         ])
     call_variants_auto(TEST_PARAMS_CH)
 }


### PR DESCRIPTION
Hey @Abhi18av here goes my changes suggesting the usage of `path()` instead of `file()` for all the modules, but I've not touched the `file()` usage on `main.nf.` The modules use the method `getName()`, I tested and this method seems to work in the same way from the objects created from `file()` and for the ones created with `path()` solving one point mentioned [here](https://github.com/bactopia/bactopia/pull/228#issuecomment-864138501)

Best Regards!
Davi